### PR TITLE
fix(hero): removed unintended icon causing app launch issue

### DIFF
--- a/src/components/Herosection.jsx
+++ b/src/components/Herosection.jsx
@@ -1,12 +1,6 @@
-import { FaLightbulb } from 'react-icons/fa';
-
 export default function Herosection() {
     return (
                 <div className="flex flex-col items-center text-center">
-                {/* Lightbulb Icon */}
-                <div className="flex justify-centre -mb-2">
-                    <FaLightbulb className="text-yellow-400 text2xl" />
-                </div>
                 <h1 className="text-5xl font-bold text-gray-900 mb-6 leading-tight">
                     Discover Smarter Ways to Learn
                 </h1>


### PR DESCRIPTION
## 🛠️ Changes Made  
- Removed unintended `FaLightbulb` icon from `HeroSection.jsx`  
- Eliminated dependency on `react-icons` in this component  

## 🐛 Root Cause  
The icon was:  
- Not part of the original design spec  
- Causing module resolution conflicts during launch  

## ✅ Verification Steps  
1. Tested locally:  
   ```bash  
   npm run dev  